### PR TITLE
build: Add macro for sha1 checked add-radio-file

### DIFF
--- a/build/core/utils.mk
+++ b/build/core/utils.mk
@@ -201,3 +201,12 @@ $(strip \
   $(if $(strip $(acn)),true,) \
 )
 endef
+
+# $(call add-radio-file-sha1-checked,path,sha1)
+define add-radio-file-sha1-checked
+  $(eval path := $(LOCAL_PATH)/$(1))
+  $(eval sha1 := $(shell sha1sum "$(path)" | cut -d" " -f 1))
+  $(if $(filter $(sha1),$(2)),
+    $(call add-radio-file,$(1)),
+    $(error $(path) SHA1 mismatch ($(sha1) != $(2))))
+endef


### PR DESCRIPTION
This makes it slightly safer in case radio/*.img contains LFS pointer instead of actual blob.

Change-Id: Ia3561400c62675eac9f717f7eae74e4cdf71cf45
